### PR TITLE
Filter by os_family to support Debian derivatives.

### DIFF
--- a/network-debian/map.jinja
+++ b/network-debian/map.jinja
@@ -5,4 +5,4 @@
     'pkgs_vlan': ['vlan'],
     'confdir': '/etc/network',
 },
-}, grain='os', merge=salt['pillar.get']('network:lookup')) %}
+}, grain='os_family', merge=salt['pillar.get']('network:lookup')) %}


### PR DESCRIPTION
Since this state can be used on Ubuntu and other Debian derivatives, it should filter on os_family instead.
