### PR TITLE
Check if pillar is available before accessing it

### DIFF
--- a/network-debian/init.sls
+++ b/network-debian/init.sls
@@ -11,7 +11,9 @@ network_remove_resolvconf:
   pkg.removed:
     - name: resolvconf
 
-
+{%- set network = salt['pillar.get']('network', {}) %}
+{%- set interfaces = network.get('interfaces', {}) %}
+{%- if not interfaces.get('keep', false) %}
 /etc/network/interfaces:
   file.managed:
     - user: root
@@ -21,6 +23,7 @@ network_remove_resolvconf:
     - source:   salt://network-debian/files/interfaces.jinja
     - context:
       interfaces: {{ pillar.network.get('interfaces',{}) }}
+{%- endif %}
 
 /etc/network/routes:
   file.managed:

--- a/network-debian/init.sls
+++ b/network-debian/init.sls
@@ -6,6 +6,7 @@
 
 # remove resolvconf package - we want to control resolv.conf ourselves.
 #
+{%- if 'network' in pillar %}
 network_remove_resolvconf:
   pkg.removed:
     - name: resolvconf
@@ -43,5 +44,4 @@ network_remove_resolvconf:
       dnsserver: {{ pillar.network.get('dnsserver',[]) }}
       dnsdomain: {{ pillar.network.get('dnsdomain', 'localnet') }}
       dnssearch: {{ pillar.network.get('dnssearch', []) }}
-
-
+{%- endif %}


### PR DESCRIPTION
In the current state the formula tries to access pillar data without ever checking whether or not the pillar data is available. Thereby adding the formula to your environment might result in your SLS files failing to render with the error message `Rendering SLS 'base:network-debian' failed: Jinja variable 'salt.utils.context.NamespacedDictWrapper object' has no attribute 'network'`

This patch checks if there is any pillar data available to access. If the pillar data does not contain anything named `network` it will not change anything in the system. Furthermore it adds a `keep` flag for interefaces. Thereby it is possible to maintain interface config, but still configure resolvconf and routing.